### PR TITLE
SEO: redirect default Netlify subdomain

### DIFF
--- a/static/_redirects
+++ b/static/_redirects
@@ -1,0 +1,2 @@
+# Redirect default Netlify subdomain to primary domain
+https://tristandefommervault.netlify.com/* https://tristandefommervault.com/:splat 301!


### PR DESCRIPTION
Cette PR a pour but de rediger le sous-domaine http://tristandefommervault.netlify.com/ vers tristandefommervault.com/

La redirection se fait à l'aide de fichier de redirections, tel que documenté ici: https://www.netlify.com/docs/redirects/